### PR TITLE
Changes to reflect dropping Taiga and just using GitHub issues.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,26 @@
 # Contributing
-If you would like to contribute to the project, please feel free to submit a pull request. For the best chance of success getting your pull request merged, please do the following few things:
+I welcome contributions and suggestions for EmergentMUD! If you would like to contribute to the project, here are some basic guidelines.
 
-1. Check the tickets on [Taiga](https://tree.taiga.io/project/scionaltera-emergentmud/) to see if what you want to do is there already. If it isn't, check the [Roadmap](https://github.com/scionaltera/emergentmud/wiki/Product-Roadmap) to see if it's something I'm planning to work on later. Discuss your proposed change with the dev team before doing the work. I can either assign the ticket to you or create a new ticket as necessary. If what you want to do isn't in line with the vision for EmergentMUD, you are still more than welcome to fork it and develop the code on your own.
-1. Fork a copy of the project.
-1. Match the coding style of existing code as best as possible.
-1. Make sure the code you are contributing is covered by unit tests.
-1. Document your work, or include updates to the existing documentation as necessary.
-1. Include the license header in any new files that you create. Please note that contributing your code means you will give up ownership of it in the legal sense. I will of course still recognize and appreciate your contribution but I will not be able to pull your code back out if you change your mind later.
-1. Finally, submit your pull request from your fork back to the project. I will work with you to get it reviewed and merged.
+## Check for existing planned work
+
+Check the open GitHub issues to see if what you want to do is there already. If it isn't, check the [Roadmap](https://github.com/scionaltera/emergentmud/wiki/Product-Roadmap) to see if it's something that work has already been planned for.
+
+I strongly recommend discussing your proposed changes by opening an issue before doing work on it, just to avoid duplicated and wasted effort. I can either assign a ticket to you or we can create a new ticket as necessary. If what you want to do isn't in line with the vision for EmergentMUD, you are still more than welcome to fork it and take it in your own direction.
+
+## Code style
+
+* Use a descriptive branch name. Name it after an issue, or describe the feature you're adding. For example: `improve-npc-pathfinding` or `fix-issue-93`.
+* Please try to match the coding style (indentations, brackets, variable names, etc.) of existing code as best as possible.
+* Make sure the code you are contributing is covered by unit tests, and that `./gradlew clean buildDocker` fully passes.
+* Document your work, or include updates to the existing documentation as necessary.
+* Include the license header in any new files that you create.
+
+If you get stuck or have questions, go ahead and open the pull request. I'll be glad to discuss it with you and guide you through any revisions that might be necessary before it can be merged.
+
+## Start small
+
+If you have not contributed to EmergentMUD before, consider looking for an issue labeled `good first issue` for your first contribution. If there isn't one that you want to work on, consider proposing a new issue first. Doing so will help to plan the work you'd like to do and ensure that it's in line with EmergentMUD's direction before committing a lot of time and effort to it.
+
+## Becoming a Collaborator
+
+I am not seeking additional Collaborators at this time, but if the right person comes along I'll approach them about it. I expect this stance to change as the game becomes more playable and a community begins to form around EmergentMUD.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-[![AGPL License](https://img.shields.io/github/license/scionaltera/emergentmud.svg "AGPL License")](http://www.gnu.org/licenses/agpl.txt)  
 [![Website](https://img.shields.io/website/https/emergentmud.com.svg?label=game "Game Website")](https://emergentmud.com)
 [![Dev Blog](https://img.shields.io/website/https/emergentmud.blogspot.com.svg?label=blog "Development Blog")](https://emergentmud.blogspot.com)
-[![Tracker](https://img.shields.io/website/https/tree.taiga.io.svg?label=tracker "Project Tracker")](https://tree.taiga.io/project/scionaltera-emergentmud)  
-[![Codeship Status for scionaltera/emergentmud](https://img.shields.io/codeship/2e55adc0-182e-0135-2909-5a38df18d274/master.svg)](https://codeship.com/projects/218829)
-[![GitHub Closed PRs](https://img.shields.io/github/issues-pr-closed/scionaltera/emergentmud.svg)](https://github.com/scionaltera/emergentmud)  
-[![Docker Automated build](https://img.shields.io/docker/automated/scionaltera/emergentmud.svg)](https://hub.docker.com/r/scionaltera/emergentmud/)
+[![Codeship Status for scionaltera/emergentmud](https://img.shields.io/codeship/2e55adc0-182e-0135-2909-5a38df18d274/master.svg)](https://codeship.com/projects/218829)  
+[![GitHub Issues](https://img.shields.io/github/issues/scionaltera/emergentmud.svg)](https://github.com/scionaltera/emergentmud/issues)
+[![GitHub PRs](https://img.shields.io/github/issues-pr/scionaltera/emergentmud.svg)](https://github.com/scionaltera/emergentmud)  
 [![Docker Pulls](https://img.shields.io/docker/pulls/scionaltera/emergentmud.svg)](https://hub.docker.com/r/scionaltera/emergentmud/)
 [![Docker Stars](https://img.shields.io/docker/stars/scionaltera/emergentmud.svg)](https://hub.docker.com/r/scionaltera/emergentmud/)
 
@@ -16,7 +14,7 @@ Help an NPC gather resources to build his house and he'll build his house - not 
 # Current State
 The code has been in active development for about two years now, and still going strong although there is still a very long way to go. Please [drop in](https://emergentmud.com) and take a look around, and pardon the dust. Let me know what you think. New things are being added on a regular basis.
 
-If you're a programmer, check out the MUD's source code and see what you think. If you're a gamer, I'd love to hear your feedback. I talk a lot about the development process on the [blog](http://emergentmud.blogspot.com) and you can track my work on [GitHub](https://github.com/scionaltera/emergentmud) and [Taiga](https://tree.taiga.io/project/scionaltera-emergentmud/) to see what features are currently being worked on. **Thanks for visiting!**
+If you're a programmer, check out the MUD's source code and see what you think. If you're a gamer, I'd love to hear your feedback. I talk a lot about the development process on the [blog](http://emergentmud.blogspot.com) and you can track my work on [GitHub](https://github.com/scionaltera/emergentmud) to see what features are currently being worked on. **Thanks for visiting!**
 
 Our current release is called `Playable World`. It is focused on all the most basic necessities of a MUD.
 
@@ -34,85 +32,6 @@ Our next release is called `The Environment`. It will focus on developing a few 
 * Character Attributes
 * Equipment
 * Animals
-
-# Running Locally
-## Required Tools
-If you want to run a copy of EmergentMUD locally from the public Docker image, you need to have [Docker](https://www.docker.com/products/docker) installed. Make sure that when you install Docker on your machine you also get [Docker Compose](https://docs.docker.com/compose/). In most cases the installer will install both tools for you at once.
-
-These instructions assume that you are somewhat familiar with using the command line or terminal for typing commands in on your machine, that you have a working network connection, a programmer's text editor such as `vim` or `Sublime Text`, a web browser, and that you are comfortable with installing software.
-
-## Required Configuration
-Make an empty directory somewhere on your computer, where you want the MUD's files to live. You'll need to create two new text files in that directory: `secrets.env` and `docker-compose.yaml`.
-
-The first file is called `secrets.env`. The file should look like [secrets.env.sample](https://github.com/scionaltera/emergentmud/blob/master/secrets.env.sample) in the git repository except that you need to fill in all the missing values. To do that, you'll need to go to [Facebook](https://developers.facebook.com) and [Google](https://console.developers.google.com) to register your application and get their IDs and secrets for OAuth. The details of how to do this are out of scope for this document, but both sites have pretty good help for how to get started. Please remember that the OAuth secrets are *secret*, and should be treated as such. Don't share them with other people and don't check them into your version control.
-
-The second file is called `docker-compose.yaml`. The file should look something like this:
-
-```yaml
-version: "2"
-services:
-  mongo:
-    image: mongo
-    ports:
-     - "27017"
-  emergentmud:
-    image: scionaltera/emergentmud:latest
-    ports:
-     - "8080:8080"
-     - "5005:5005"
-    links:
-     - mongo
-    env_file: secrets.env
-```
-
-This file tells Docker that you want a [MongoDB](https://www.mongodb.com) instance and an EmergentMUD instance. It describes which ports to open on each, and how the networking should link together between them.
-
-## Starting the Server
-The command to get everything started is `docker-compose up`. You should see it download and extract all the Docker images, then the logs will scroll by as the services start up. When they're done booting, point your browser at http://localhost:8080 (or the IP for your docker VM if you're using boot2docker) and you should see the front page for EmergentMUD. If you have configured everything correctly for OAuth in Facebook and Google, you should be able to log in and play.
-
-# Local Development
-## Required Tools
-The code is built using the [Gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html). The project structure follows the typical [Maven structure](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html) and is designed to be easy to set up locally for testing using Docker and Docker Compose. You will need the following tools installed and properly configured to run the site locally:
-
-1. Java 8 or later.
-1. Docker and Docker Compose.
-
-## Required Configuration
-The configurable settings for integrating with Facebook and Google are stored in a file called `secrets.env`. There is a sample of this file included in the git repository which you will need to rename and fill out the information for your integrations. In order to get the API tokens you will need to register your application on the developer sites for [Facebook](https://developers.facebook.com) and [Google](https://console.developers.google.com). Please remember that the OAuth secrets are *secret* and should be treated as such. Make sure not to check them in to your version control or share them with other people.
-
-## Compiling the Project
-To start up the site after you set up the env file, you just need to run `./gradlew clean buildDocker` from the command line. That will build the project, run the tests, and finally build the Docker image. To start everything up after it's done building, type `docker-compose up`.
-
-## Running the Project
-The first time you run `docker-compose up` will take some time because it needs to download the MongoDB container. After they are downloaded and unpacked, you should see the logs for all of the services starting up. Once everything has started up, point your browser at `http://localhost:8080` (or your docker VM if you're using boot2docker) and you should see the front page. If you have configured everything correctly in Facebook and Google, you should be able to log in and play.
-
-## Developing New Code
-If you want to run your own copy of EmergentMUD there are probably a thousand things you want to customize. Your best bet is going to be to fork the project on GitHub, write your new code and build your own Docker containers from your fork.
-
-## Debugging
-The Docker image produced by the Gradle build is already set up to enable the remote debugging port on port 5005. I use IDEA for development, which makes it very easy to [set up a remote debug profile](http://stackoverflow.com/questions/21114066/attach-intellij-idea-debugger-to-a-running-java-process). Once you're attached, you can set breakpoints and inspect variables to your heart's content.
-
-## Considerations for Production Deployments
-### Secrets
-I recommend registering both a production and a test app in Facebook and Google. Things like allowed redirect URIs and analytics can get difficult if you don't keep dev separate from production.
-
-Facebook has built in functionality for creating a "test" version of your application in their console, while for Google you just need to generate two sets of credentials for your application. Put one `secrets.env` on your production box and the other in your dev environment, and you're all set.
-
-In Google you can simply create two sets of credentials for the same application.
-
-### Data Stores
-The Docker containers for the MongoDB data store is sufficient for development but is **not configured for security or performance** at all. It is just the default containers off the web. On my machine it [complains about Transparent Huge Pages being enabled](https://www.digitalocean.com/company/blog/transparent-huge-pages-and-alternative-memory-allocators/) and will most likely gobble up large amounts of memory and eventually crash if you just leave them running long term. So far though, that's exactly what I've been doing and it has worked out well enough. I expect that will change when there is a regular player base.
-
-If you plan to run EmergentMUD for real, it would be a good idea to carefully configure your MongoDB instance according to the best practices spelled out in its documentation. You should also consider running it as a cluster so it is highly available. How to do all of this is well out of scope for this document, but there are lots of resources on the internet that will tell you how to do it if you are curious.
-
-My plan for a production deployment of EmergentMUD is to build customized Docker containers for the data stores, based on the ones in use today but with an extra layer that applies the configuration changes that I need for deployment. That way I can still run my production cluster of services using `docker-compose`, [Docker Swarm](https://docs.docker.com/engine/swarm/), [Kubernetes](https://kubernetes.io/) or something similar. Today, however, I'm just running the off-the-shelf images until they become a problem.
-
-### Reverse Proxy
-It is important to understand that OAuth2 is **not secure without HTTPS**. That means that for any production deployment to be secure you *must* purchase an **SSL certificate** and configure a SSL enabled reverse proxy in front of your copy of EmergentMUD. If you do not do this you **will** leak peoples' authentication secrets for their Google and Facebook accounts, and that is **really bad**.
-
-![Service Architecture](https://emergentmud.com/img/em-docker-compose.png)
-
-What I have done with [EmergentMUD's dev server](https://emergentmud.com) is to add an [nginx reverse proxy Docker container](https://hub.docker.com/r/jwilder/nginx-proxy/) to my `docker-compose.yaml` and configure it with my SSL certificate. Incoming connections are automatically upgraded to SSL at nginx, and through some sort of wicked sorcery the requests are dynamically routed to the MUD's container. The MUD doesn't need to know anything about SSL, and everybody is happy and safe. The data stores aren't accessible from the internet, which is great for their security. There is a version of my [production docker-compose.yaml](https://github.com/scionaltera/emergentmud/wiki/Production-Docker-Compose-Configuration) on the wiki which should help most people get started. It uses *free* SSL certificates from [letsencrypt](https://letsencrypt.org) to provide the encryption necessary for secure OAuth2.
 
 # Contact
 So far the dev team consists of just me, Scion. I am not looking for partners or MUD staff at this time but I welcome discussion about the future direction of EmergentMUD and I welcome pull requests and forks. I'd love to know if you have used any of my code for your own project. The best motivation for me to continue work on the project is to know that other people are interested and making use of it.

--- a/src/main/resources/templates/external-links.inc.ftl
+++ b/src/main/resources/templates/external-links.inc.ftl
@@ -1,7 +1,6 @@
 <div class="col-md-12 text-center margin-bottom">
     [ <a href="https://emergentmud.blogspot.com" target="_blank">Development Blog</a> ]
     [ <a href="https://github.com/scionaltera/emergentmud" target="_blank">Source Code</a> ]
-    [ <a href="https://tree.taiga.io/project/scionaltera-emergentmud/" target="_blank">Issue Tracker</a> ]
     [ <a href="https://hub.docker.com/r/scionaltera/emergentmud/" target="_blank">Docker Hub</a> ]
     [ <a href="https://uptime.emergentmud.com" target="_blank">Server Uptime</a> ]
 </div>


### PR DESCRIPTION
Fixes #18. Above all, the fact that they're built into GitHub was the deciding factor. I like that everything is now in one place and I don't have to hope people click a link over to something they may not have seen or used before. Issues on GitHub are still a little rudimentary but with issues, milestones and projects I can definitely make it work.

* Removed references to Taiga.
* Updated contribution guidelines.
* Removed a bunch of stuff from the README and moved it to the Wiki.