### PR TITLE
Remove references to the blog and de-duplicate product roadmap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Website](https://img.shields.io/website/https/emergentmud.com.svg?label=game "Game Website")](https://emergentmud.com)
-[![Dev Blog](https://img.shields.io/website/https/emergentmud.blogspot.com.svg?label=blog "Development Blog")](https://emergentmud.blogspot.com)
 [![Codeship Status for scionaltera/emergentmud](https://img.shields.io/codeship/2e55adc0-182e-0135-2909-5a38df18d274/master.svg)](https://codeship.com/projects/218829)  
 [![GitHub Issues](https://img.shields.io/github/issues/scionaltera/emergentmud.svg)](https://github.com/scionaltera/emergentmud/issues)
 [![GitHub PRs](https://img.shields.io/github/issues-pr/scionaltera/emergentmud.svg)](https://github.com/scionaltera/emergentmud)  
@@ -7,36 +6,17 @@
 [![Docker Stars](https://img.shields.io/docker/stars/scionaltera/emergentmud.svg)](https://hub.docker.com/r/scionaltera/emergentmud/)
 
 # Vision
-EmergentMUD is a free, text based "Multi-User Domain" that you play in your browser. It's a modern MUD with an old school retro feel. Just like most other MUDs back in the 90s you play a character in a medieval fantasy setting. The modern aspect is that the entire game world is procedurally generated on the fly and is fully interactive. All parts of the world from the species of plants and animals, societies of sentient creatures, geography, weather, and even quests are created on demand as players explore. All the different game systems interact with one another to create fun and unexpected *emergent behavior*. This world is alive.
+EmergentMUD is a free, open source, text based "Multi-User Domain" that you play in your browser. It's a modern MUD with an old school retro feel. Just like most other MUDs back in the 90s you play a character in a medieval fantasy setting. The modern aspect is that the entire game world is procedurally generated on the fly and is fully interactive. All parts of the world from the species of plants and animals, societies of sentient creatures, geography, weather, and even quests are created on demand as players explore. All the different game systems interact with one another to create fun and unexpected *emergent behavior*. This world is alive.
 
 Help an NPC gather resources to build his house and he'll build his house - not just continue asking everyone he sees for resources. Steal the gold from the King's vault and he won't be able to fund the war he's waging - having a direct effect on international politics. Burn down a village and maybe it will be rebuilt - but maybe it won't. Help someone in need and make an ally you can rely on later. Start a business and hire NPCs to work for you. Head out in a direction that isn't on the map yet and it will be created as you begin to walk through it - complete with new plants, animals, NPCs, religions, cultures and discoveries that the world has never seen before. Everything you do in this world has a real effect. You won't see any quest vendors and you won't experience the same "content" that everyone else has already devoured before you. You can forge your own path, create your own destiny, and leave your own mark upon the world in the process.
 
 # Current State
-The code has been in active development for about two years now, and still going strong although there is still a very long way to go. Please [drop in](https://emergentmud.com) and take a look around, and pardon the dust. Let me know what you think. New things are being added on a regular basis.
-
-If you're a programmer, check out the MUD's source code and see what you think. If you're a gamer, I'd love to hear your feedback. I talk a lot about the development process on the [blog](http://emergentmud.blogspot.com) and you can track my work on [GitHub](https://github.com/scionaltera/emergentmud) to see what features are currently being worked on. **Thanks for visiting!**
-
-Our current release is called `Playable World`. It is focused on all the most basic necessities of a MUD.
-
-* Application framework and architecture
-* Production deployment with Docker
-* Administrative commands and tools
-* Basic room generation
-* Communication, emotes and movement commands
-* Help files
-
-Our next release is called `The Environment`. It will focus on developing a few of the key things a MUD world needs to feel "alive".
-
-* Bodies of Water
-* Non-Player Characters
-* Character Attributes
-* Equipment
-* Animals
+The code has been in active development for about two years now, and still going strong although there is still a very long way to go. Please [drop in](https://emergentmud.com) and take a look around, and pardon the dust. Let me know what you think. New things are being added on a [regular basis](https://github.com/scionaltera/emergentmud/wiki/Product-Roadmap).
 
 # Contact
 So far the dev team consists of just me, Scion. I am not looking for partners or MUD staff at this time but I welcome discussion about the future direction of EmergentMUD and I welcome pull requests and forks. I'd love to know if you have used any of my code for your own project. The best motivation for me to continue work on the project is to know that other people are interested and making use of it.
 
-The best ways to contact me about this project are to message me on [Telegram](http://telegram.me/scionaltera) or comments on the [blog](https://emergentmud.blogspot.com). You could also just hop onto the [MUD](https://emergentmud.com) and see if I'm hanging around there. If you'd prefer, send me a message through GitHub and we can go from there.
+The best way to contact me about this project is to open a [GitHub issue](https://github.com/scionaltera/emergentmud/issues). You could also just hop onto the [MUD](https://emergentmud.com) and see if I'm hanging around there.
 
 # License
 EmergentMUD is licensed under the [GNU AFFERO GENERAL PUBLIC LICENSE](http://www.gnu.org/licenses/agpl.txt). This license ensures that EmergentMUD and all derivative works will always be free open source for everyone to enjoy, distribute and modify. Most importantly, the Affero license stipulates that you must be able to provide a copy of your source code to **anyone who plays your game**.

--- a/src/main/resources/templates/external-links.inc.ftl
+++ b/src/main/resources/templates/external-links.inc.ftl
@@ -1,5 +1,23 @@
+<#--
+EmergentMUD - A modern MUD with a procedurally generated world.
+Copyright (C) 2016-2018 Peter Keeler
+
+This file is part of EmergentMUD.
+
+EmergentMUD is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+EmergentMUD is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <div class="col-md-12 text-center margin-bottom">
-    [ <a href="https://emergentmud.blogspot.com" target="_blank">Development Blog</a> ]
     [ <a href="https://github.com/scionaltera/emergentmud" target="_blank">Source Code</a> ]
     [ <a href="https://hub.docker.com/r/scionaltera/emergentmud/" target="_blank">Docker Hub</a> ]
     [ <a href="https://uptime.emergentmud.com" target="_blank">Server Uptime</a> ]

--- a/src/main/resources/templates/index.ftl
+++ b/src/main/resources/templates/index.ftl
@@ -1,6 +1,6 @@
 <#--
 EmergentMUD - A modern MUD with a procedurally generated world.
-Copyright (C) 2016-2017 Peter Keeler
+Copyright (C) 2016-2018 Peter Keeler
 
 This file is part of EmergentMUD.
 
@@ -41,36 +41,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <div class="row">
         <div class="col-md-10 col-md-offset-1 description">
             <h1>The Explorer's Dream</h1>
-            <p>EmergentMUD is a free, text based "Multi-User Domain" that you play in your browser. It's a modern MUD with an old school retro feel. Just like most other MUDs back in the 90s you play a character in a medieval fantasy setting. The modern aspect is that the entire game world is procedurally generated on the fly and is fully interactive. All parts of the world from the species of plants and animals, societies of sentient creatures, geography, weather, and even quests are created on demand as players explore. All the different game systems interact with one another to create fun and unexpected <em>emergent behavior</em>. This world is alive.</p>
+            <p>EmergentMUD is a free, open source, text based "Multi-User Domain" that you play in your browser. It's a modern MUD with an old school retro feel. Just like most other MUDs back in the 90s you play a character in a medieval fantasy setting. The modern aspect is that the entire game world is procedurally generated on the fly and is fully interactive. All parts of the world from the species of plants and animals, societies of sentient creatures, geography, weather, and even quests are created on demand as players explore. All the different game systems interact with one another to create fun and unexpected <em>emergent behavior</em>. This world is alive.</p>
             <p>Help an NPC gather resources to build his house and he'll build his house - not just continue asking everyone he sees for resources. Steal the gold from the King's vault and he won't be able to fund the war he's waging - having a direct effect on international politics. Burn down a village and maybe it will be rebuilt - but maybe it won't. Help someone in need and make an ally you can rely on later. Start a business and hire NPCs to work for you. Head out in a direction that isn't on the map yet and it will be created as you begin to walk through it - complete with new plants, animals, NPCs, religions, cultures and discoveries that the world has never seen before. Everything you do in this world has a real effect. You won't see any quest vendors and you won't experience the same "content" that everyone else has already devoured before you. You can forge your own path, create your own destiny, and leave your own mark upon the world in the process.</p>
 
             <h2>So that's the elevator pitch.</h2>
-            <p>The code has been in active development for about a year now, and still going strong although there is still a very long way to go. Please drop in and take a look around, and pardon the dust. Let me know what you think. New things are being added on a regular basis.</p>
-            <p>If you're a programmer, please check out the MUD's source code and see what you think. If you're a gamer, I'd love to hear your feedback. I talk a lot about the development process on the blog and you can track my work at the links below to see what features are currently being worked on. <strong>Thanks for visiting!</strong></p>
-
-            <h1>Development Progress</h1>
-            <p>The current release is called <em>Playable World</em>. It is focused on all the most basic necessities of a MUD.</p>
-            <ul>
-                <li>Application framework and architecture</li>
-                <li>Production deployment with Docker</li>
-                <li>Administrative commands and tools</li>
-                <li>Basic room generation with biomes</li>
-                <li>Communication, emotes and movement commands</li>
-                <li>Help files</li>
-            </ul>
-            <p>The next release is called <em>The Environment</em>. It will focus on developing the natural world inside the MUD.</p>
-            <ul>
-                <li>Bodies of Water</li>
-                <li>Plants and Trees</li>
-                <li>Minerals, Metals and Other Natural Resources</li>
-                <li>Animals</li>
-            </ul>
+            <p>The code has been in active development for about two years now, and still going strong although there is still a very long way to go. Please drop in and take a look around, and pardon the dust. Let me know what you think. New things are being added on a <a href="https://github.com/scionaltera/emergentmud/wiki/Product-Roadmap" target="_blank">regular basis</a>.</p>
         </div>
     </div>
     <div class="row">
         <div class="col-md-12 text-center margin-bottom">
             [ <a href="<@spring.url '/public/commands'/>">Commands</a> ]
             [ <a href="<@spring.url '/public/emotes'/>">Emotes</a> ]
+            [ <a href="<@spring.url 'https://github.com/scionaltera/emergentmud/wiki'/>" target="_blank">Wiki</a> ]
         </div>
     </div>
     <div class="row">

--- a/src/main/resources/templates/scripts.inc.ftl
+++ b/src/main/resources/templates/scripts.inc.ftl
@@ -1,3 +1,22 @@
+<#--
+EmergentMUD - A modern MUD with a procedurally generated world.
+Copyright (C) 2016-2018 Peter Keeler
+
+This file is part of EmergentMUD.
+
+EmergentMUD is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+EmergentMUD is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
 <script type="text/javascript" src="/webjars/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="/webjars/bootstrap/js/bootstrap.min.js"></script>
 <#if addThis??>


### PR DESCRIPTION
I'm centralizing everything around GitHub. The blog wasn't getting updated all that often and never attracted much traffic. Just like with backlog I think I'd like to drive people to the GitHub wiki to read information about EmergentMUD, and the wiki format will be more appropriate than a blog for the way I want to disseminate information. I'll definitely revisit the idea of a blog down the road as a community builds up around the game.

The first part of the product roadmap was duplicated on the wiki, the readme and the front page of the website. I shortened the readme and the front page substantially and just linked to the roadmap wiki article. That way there's no danger of things getting out of sync and the roadmap page is just more informative anyway.

Also added the copyright header to a couple files that didn't have it.