### PR TITLE
More codeship config

### DIFF
--- a/Dockerfile.codeship
+++ b/Dockerfile.codeship
@@ -24,7 +24,7 @@ RUN cd /opt/build \
 && apk update \
 && apk upgrade \
 && apk add --no-cache bash \
-&& ./gradlew clean build -x check
+&& ./gradlew clean build -x dependencyCheck
 
 FROM frolvlad/alpine-oraclejre8:slim
 MAINTAINER Peter Keeler <scion@emergentmud.com>

--- a/Dockerfile.codeship
+++ b/Dockerfile.codeship
@@ -26,7 +26,7 @@ RUN cd /opt/build \
 && apk add --no-cache bash \
 && ./gradlew clean build -x check
 
-FROM frovlad/alpine-oraclejre8:slim
+FROM frolvlad/alpine-oraclejre8:slim
 MAINTAINER Peter Keeler <scion@emergentmud.com>
 EXPOSE 8080
 COPY --from=build /opt/build/build/libs/emergentmud-*.jar /opt/mud/app.jar

--- a/Dockerfile.codeship
+++ b/Dockerfile.codeship
@@ -23,4 +23,11 @@ COPY . /opt/build/
 RUN cd /opt/build \
 && apk update \
 && apk upgrade \
-&& apk add --no-cache bash
+&& apk add --no-cache bash \
+&& ./gradlew clean build -x check
+
+FROM frovlad/alpine-oraclejre8:slim
+MAINTAINER Peter Keeler <scion@emergentmud.com>
+EXPOSE 8080
+COPY --from=build /opt/build/build/libs/emergentmud-*.jar /opt/mud/app.jar
+CMD ["/usr/bin/java", "-jar", "/opt/mud/app.jar"]

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -16,9 +16,9 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: build
+- name: test
   service: emergentmud
-  command: ./gradlew clean build -x dependencyCheck
+  command: ./gradlew check -x dependencyCheck
 - name: tag_latest
   service: emergentmud
   type: push

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -16,9 +16,9 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: test
+- name: build
   service: emergentmud
-  command: ./gradlew check -x dependencyCheck
+  command: echo "Build complete!"
 - name: tag_latest
   service: emergentmud
   type: push


### PR DESCRIPTION
It works better if you do it right.

My updated config prior to this stopped short of actually building a runnable Docker image. It only built an environment in which my project could be built. The Codeship documentation is very light on the nuts and bolts of how this is supposed to work. The short of it is that now I build a working Docker container in `Dockerfile.codeship` and so that my build doesn't end prematurely I have a placeholder step that always runs and simply echoes a message. That way branch builds that don't need to be pushed still compile and run tests, which was all I was going for at this point.